### PR TITLE
Add common header to each page

### DIFF
--- a/src/app/events/page.jsx
+++ b/src/app/events/page.jsx
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import Head from 'next/head';
 import Eventv2 from '../../components/Calendar/Eventv2';
 import styles from '../../styles/App.module.css';
+import PageHeader from '@/components/PageHeader';
 
 const Index = () => {
   const [sectionedEvents, setSectionedEvents] = useState(null);
@@ -50,6 +51,10 @@ const Index = () => {
         </title>
       </Head>
       <div className={styles.App}>
+        <PageHeader
+          title="Upcoming Events"
+          subtitle="Stay Tuned for Exciting Upcoming Events"
+        />
         <div className="fixed bottom-6 right-6 md:bottom-10 md:right-10 ">
           {/* up arrow */}
           <a
@@ -76,12 +81,12 @@ const Index = () => {
         <div className="container-md p-4 min-h-[95vh]">
           {/* <Calendar events={events.events}/> */}
           <div className="flex justify-between">
-            <h1
+            {/* <h1
               className="text-left text-3xl md:text-5xl"
               id="upcoming-events-title"
             >
               Upcoming Events
-            </h1>
+            </h1> */}
             <div className="flex flex-row flex-wrap max-w-[400px] justify-end">
               {sectionedEvents
                 ? Object.keys(sectionedEvents).map((monthYear, index) => {

--- a/src/app/newsletters/page.jsx
+++ b/src/app/newsletters/page.jsx
@@ -1,8 +1,6 @@
 'use client';
 
 import React from 'react';
-import NewsLetter from '@/components/Newsletter/templates/Newsletter';
-import Section from '@/components/Newsletter/templates/Section';
 import TwoColumn from '@/components/Newsletter/templates/TwoColumn';
 import TwoRow from '@/components/Newsletter/templates/TwoRow';
 import Image from '@/components/Newsletter/templates/Image';
@@ -12,6 +10,7 @@ import List from '@/components/Newsletter/templates/List';
 import NewsletterCard from '@/components/Newsletter/NewsletterCard';
 import Head from 'next/head';
 import data from '../../data/newsletter.json';
+import Newsletter from '@/components/Newsletter/templates/Newsletter';
 
 const components = {
   Paragraph: Paragraph,
@@ -30,9 +29,9 @@ const Index = () => {
           Newsletter | American Institute of Aeronautics and Astronautics
         </title>
       </Head>
-      <NewsLetter
+      <Newsletter
         title="Newsletter"
-        subtitle="Here you'll find our monthly newsletters with the latest news and updates."
+        subtitle="Stay Connected with Our Vibrant Newsletters"
       >
         <div className="my-8 flex flex-row flex-wrap justify-center gap-12">
           {data
@@ -43,7 +42,7 @@ const Index = () => {
               return <NewsletterCard key={index} {...item} />;
             })}
         </div>
-      </NewsLetter>
+      </Newsletter>
     </>
   );
 };

--- a/src/app/team/page.jsx
+++ b/src/app/team/page.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Team from '../../components/Team/Team';
 import Head from 'next/head';
+import PageHeader from '@/components/PageHeader';
 
 const Index = () => {
   return (
@@ -11,6 +12,7 @@ const Index = () => {
         <title>Team | American Institute of Aeronautics and Astronautics</title>
       </Head>
       <div>
+        <PageHeader title="Team" subtitle="Meet Our Dedicated Team" />
         <Team />
       </div>
     </>

--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -1,0 +1,23 @@
+export default function PageHeader({
+  title,
+  subtitle,
+  backgroundImage,
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center w-full h-full bg-slate-900">
+      <div
+        style={{
+          backgroundImage: `url(${backgroundImage})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
+          backgroundBlendMode: 'darken',
+        }}
+        className="p-12 w-full bg-gray-800/50"
+      >
+        <h1 className="text-3xl font-bold text-center">{title}</h1>
+        <p className="text-center">{subtitle}</p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
I added a component called `PageHeader` to the 'Events' and 'Team' pages. The same format can be found in 'Newsletter' for the page header. Did not add it to the contact page because it might be redesigned more anyways.

This makes progress for #54, background image can be added if needed.